### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,5 @@ runs:
     - name: Install Poetry ${{ inputs.python-version }}
       shell: bash
       run: |
-        curl -O -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py
-        python get-poetry.py -y --preview
-        echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+        curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+        echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV


### PR DESCRIPTION
This PR changes the way poetry is installed. The `get-poetry.py` file is downloaded and then installed. This way, it would be causing `flake8` issues in the build.

https://github.com/vchrombie/release-tools/runs/2263445751?check_suite_focus=true

It also updates the way the environment variables are set as the previous method is outdated.

https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/